### PR TITLE
Simplify entity constructor type transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   "homepage": "https://github.com/junglebarry/jsonapi-transformers#readme",
   "dependencies": {},
   "devDependencies": {
-    "@types/jasmine": "^2.5.46",
-    "@types/node": "^7.0.8",
-    "del": "^2.2.2",
-    "gulp": "^3.9.1",
-    "gulp-jasmine": "^2.4.2",
-    "gulp-typescript": "^3.1.6",
-    "typescript": "^2.2.1"
+    "@types/jasmine": "2.5.46",
+    "@types/node": "7.0.8",
+    "del": "2.2.2",
+    "gulp": "3.9.1",
+    "gulp-jasmine": "2.4.2",
+    "gulp-typescript": "3.1.6",
+    "typescript": "2.2.1"
   }
 }

--- a/src/decorators/entity.ts
+++ b/src/decorators/entity.ts
@@ -45,36 +45,13 @@ export function entity(options: EntityOptions): ClassDecorator {
   const { type } = options;
 
   return (constructor: ResourceIdentifierConstructor) => {
-    const original = constructor;
-
-    // a utility function to generate instances of a class
-    const construct = (constructorFunc: ResourceIdentifierConstructor, args) => {
-      const constructorClosure : any = function () {
-        return constructorFunc.apply(this, args);
-      }
-      constructorClosure.prototype = constructorFunc.prototype;
-
-      // construct an instance and bind "type" correctly
-      const instance = new constructorClosure();
-      instance.type = type;
-      return instance;
-    };
-
-    // the new constructor behaviour
-    const wrappedConstructor : any = (...args) => construct(original, args);
-
-    // copy prototype so intanceof operator still works
-    wrappedConstructor.prototype = original.prototype;
-
-    // transfer the original function name for pretty-printing
-    Object.defineProperty(wrappedConstructor, 'name', { writable: true });
-    wrappedConstructor.name = original.name;
-    Object.defineProperty(wrappedConstructor, 'name', { writable: false });
+    // add the type to all instances by prototypical inheritance
+    constructor.prototype.type = type;
 
     // add the type to the reverse lookup for deserialisation
-    ENTITIES_MAP.set(type, wrappedConstructor);
+    ENTITIES_MAP.set(type, constructor);
 
     // return new constructor (will override original)
-    return wrappedConstructor;
+    return constructor;
   }
 }

--- a/src/serialisation/deserialisers.ts
+++ b/src/serialisation/deserialisers.ts
@@ -119,10 +119,9 @@ export function fromJsonApiResourceObject(jsonapiResource: ResourceObject, resou
   const metaMetadata = getMetaMetadata(targetConstructor);
   const relationshipMetadata = getRelationshipMetadata(targetConstructor);
 
-  // construct a basic instance with only ID and type specified
+  // construct a basic instance with only ID and type (by means of entity) specified
   const instance = new targetType();
   instance.id = id;
-  instance.type = type;
 
   // add to the list of deserialised objects, so recursive lookup works
   const typeAndId = byTypeAndId(instance);


### PR DESCRIPTION
The aim of the `entity` annotation is to transfer the `type` to a prototype, and then ensure its constructor can be looked up by the value of `type`.  For example:

```typescript
@entity({ type: 'addresses' })
export class Address extends JsonapiEntity {}
```

should:

0. Ensure that, for any instance of `Address`, `instance.type === 'addresses'`
0. Make it possible to look up the type `Address` simply by having `'addresses'`

The old code for achieving this was extremely convoluted, and involved renaming the constructor function.  This added a wrapper constructor, then used `defineProperty` to rename the wrapper to have the same name as the original constructor function.  Unfortunately, this does not work in all browsers.

The new approach is much simpler: mutate the class prototype to add `type`, and let prototypal inheritance do the work for us.