### PR TITLE
Revert to original wrappedConstructor approach; removed property update

### DIFF
--- a/spec/decorators/entity.spec.ts
+++ b/spec/decorators/entity.spec.ts
@@ -19,6 +19,15 @@ address1.street = 'Acacia Road';
 address1.city = 'Nuttytown';
 address1.county = 'West Nutshire';
 
+const address1WithExplicitType: Address = new Address();
+address1WithExplicitType.id = 'address1';
+address1WithExplicitType.type = 'addresses';
+address1WithExplicitType.houseNumber = 8;
+address1WithExplicitType.street = 'Acacia Road';
+address1WithExplicitType.city = 'Nuttytown';
+address1WithExplicitType.county = 'West Nutshire';
+
+
 const address2: Address = new Address();
 address2.id = 'address2';
 address2.street = 'Mountain Drive';
@@ -38,22 +47,14 @@ describe('entity', () => {
     expect(person1).toEqual(jasmine.any(Person));
   });
 
-  it('should respect constructor names', () => {
-    expect(address1.constructor.name).toEqual(Address.name);
-    expect(address2.constructor.name).toEqual(Address.name);
-    expect(person1.constructor.name).toEqual(Person.name);
-  });
-
-  it('should pretty-print type names', () => {
-    expect(address1.constructor.name).toEqual('Address');
-    expect(address2.constructor.name).toEqual('Address');
-    expect(person1.constructor.name).toEqual('Person');
-  });
-
   it('should add a type property from the decorator definition', () => {
     expect(address1.type).toEqual('addresses');
     expect(address2.type).toEqual('addresses');
     expect(person1.type).toEqual('people');
+  });
+
+  it('should respect equality, even when type is manually specified', () => {
+    expect(address1).toEqual(address1WithExplicitType);
   });
 
   it('should permit a natural JSON interpretation', () => {

--- a/src/decorators/entity.ts
+++ b/src/decorators/entity.ts
@@ -45,13 +45,31 @@ export function entity(options: EntityOptions): ClassDecorator {
   const { type } = options;
 
   return (constructor: ResourceIdentifierConstructor) => {
-    // add the type to all instances by prototypical inheritance
-    constructor.prototype.type = type;
+    const original = constructor;
+
+    // a utility function to generate instances of a class
+    const construct = (constructorFunc: ResourceIdentifierConstructor, args) => {
+      const constructorClosure : any = function () {
+        return constructorFunc.apply(this, args);
+      }
+      constructorClosure.prototype = constructorFunc.prototype;
+
+      // construct an instance and bind "type" correctly
+      const instance = new constructorClosure();
+      instance.type = type;
+      return instance;
+    };
+
+    // the new constructor behaviour
+    const wrappedConstructor : any = (...args) => construct(original, args);
+
+    // copy prototype so intanceof operator still works
+    wrappedConstructor.prototype = original.prototype;
 
     // add the type to the reverse lookup for deserialisation
-    ENTITIES_MAP.set(type, constructor);
+    ENTITIES_MAP.set(type, wrappedConstructor);
 
     // return new constructor (will override original)
-    return constructor;
+    return wrappedConstructor;
   }
 }

--- a/src/serialisation/deserialisers.ts
+++ b/src/serialisation/deserialisers.ts
@@ -122,6 +122,7 @@ export function fromJsonApiResourceObject(jsonapiResource: ResourceObject, resou
   // construct a basic instance with only ID and type (by means of entity) specified
   const instance = new targetType();
   instance.id = id;
+  instance.type = type;
 
   // add to the list of deserialised objects, so recursive lookup works
   const typeAndId = byTypeAndId(instance);


### PR DESCRIPTION
The aim of the `entity` annotation is to transfer the `type` to a prototype, and then ensure its constructor can be looked up by the value of `type`.  For example:

```typescript
@entity({ type: 'addresses' })
export class Address extends JsonapiEntity {}
```

should:

0. Ensure that, for any instance of `Address`, `instance.type === 'addresses'`
0. Make it possible to look up the type `Address` simply by having `'addresses'`

The old code for this attempted to transfer the name of the constructor, too.  It did not work, and caused issues in some browsers.  This property redefinition has been removed in this PR.