### PR TITLE
Add the ability to extend subclasses of JsonapiEntity

### DIFF
--- a/lib/decorators/attribute.js
+++ b/lib/decorators/attribute.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var metadata_map_1 = require("./metadata-map");
+var utils_1 = require("./utils");
 var ATTRIBUTES_MAP = new metadata_map_1.MetadataMap();
 function attribute(options) {
     var opts = options || {};
@@ -12,6 +13,6 @@ function attribute(options) {
 }
 exports.attribute = attribute;
 function getAttributeMetadata(target) {
-    return ATTRIBUTES_MAP.getMetadataByType(target.name);
+    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, ATTRIBUTES_MAP.getMetadataByType(prototype.name)); }, {});
 }
 exports.getAttributeMetadata = getAttributeMetadata;

--- a/lib/decorators/link.js
+++ b/lib/decorators/link.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var metadata_map_1 = require("./metadata-map");
+var utils_1 = require("./utils");
 var LINKS_MAP = new metadata_map_1.MetadataMap();
 function link(options) {
     var opts = options || {};
@@ -12,6 +13,6 @@ function link(options) {
 }
 exports.link = link;
 function getLinkMetadata(target) {
-    return LINKS_MAP.getMetadataByType(target.name);
+    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, LINKS_MAP.getMetadataByType(prototype.name)); }, {});
 }
 exports.getLinkMetadata = getLinkMetadata;

--- a/lib/decorators/meta.js
+++ b/lib/decorators/meta.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var metadata_map_1 = require("./metadata-map");
+var utils_1 = require("./utils");
 var META_PROPERTIES_MAP = new metadata_map_1.MetadataMap();
 function meta(options) {
     var opts = options || {};
@@ -12,6 +13,6 @@ function meta(options) {
 }
 exports.meta = meta;
 function getMetaMetadata(target) {
-    return META_PROPERTIES_MAP.getMetadataByType(target.name);
+    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, META_PROPERTIES_MAP.getMetadataByType(prototype.name)); }, {});
 }
 exports.getMetaMetadata = getMetaMetadata;

--- a/lib/decorators/relationship.js
+++ b/lib/decorators/relationship.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var metadata_map_1 = require("./metadata-map");
+var utils_1 = require("./utils");
 var RELATIONSHIPS_MAP = new metadata_map_1.MetadataMap();
 var DefaultRelationshipOptions = {
     allowUnresolvedIdentifiers: false,
@@ -15,6 +16,6 @@ function relationship(options) {
 }
 exports.relationship = relationship;
 function getRelationshipMetadata(target) {
-    return RELATIONSHIPS_MAP.getMetadataByType(target.name);
+    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, RELATIONSHIPS_MAP.getMetadataByType(prototype.name)); }, {});
 }
 exports.getRelationshipMetadata = getRelationshipMetadata;

--- a/lib/decorators/utils.d.ts
+++ b/lib/decorators/utils.d.ts
@@ -1,0 +1,1 @@
+export declare function getEntityPrototypeChain(targetType: any): any[];

--- a/lib/decorators/utils.js
+++ b/lib/decorators/utils.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var jsonapi_1 = require("../jsonapi");
+function getEntityPrototypeChain(targetType) {
+    var proto = Object.getPrototypeOf(targetType);
+    if (proto.prototype instanceof jsonapi_1.JsonapiEntity) {
+        return getEntityPrototypeChain(proto).concat([targetType]);
+    }
+    return [targetType];
+}
+exports.getEntityPrototypeChain = getEntityPrototypeChain;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Typescript-based JSON API serialisation/deserialisation",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Typescript-based JSON API serialisation/deserialisation",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/spec/serialisation/deserialisers.spec.ts
+++ b/spec/serialisation/deserialisers.spec.ts
@@ -8,16 +8,20 @@ import {
 
 import {
   Address,
+  Animal,
+  Cat,
+  Mouse,
   Person,
 } from '../test-data';
 
 import { FAKE_SINGLE_RESPONSE } from './fake-single-response.json';
+import { FAKE_SINGLE_SUBTYPE_RESPONSE } from './fake-single-subtype-response.json';
 import { FAKE_MULTIPLE_RESPONSE } from './fake-multiple-response.json';
 
 describe('deserialisers', () => {
   describe('fromJsonApiTopLevel', () => {
     describe('JSON API top-level datum deserialisation', () => {
-      const { deserialised, referents } = fromJsonApiTopLevel(FAKE_SINGLE_RESPONSE)
+      const { deserialised, referents } = fromJsonApiTopLevel(FAKE_SINGLE_RESPONSE);
       const PERSON_1: Person = deserialised;
 
       it('should deserialise the top-level datum from the response, populating object attributes', () => {
@@ -91,8 +95,8 @@ describe('deserialisers', () => {
       });
     });
 
-    describe('JSON API top-level datum deserialisation', () => {
-      const { deserialised, referents } = fromJsonApiTopLevel(FAKE_MULTIPLE_RESPONSE)
+    describe('JSON API top-level data deserialisation', () => {
+      const { deserialised, referents } = fromJsonApiTopLevel(FAKE_MULTIPLE_RESPONSE);
       const PEOPLE: Person[] = deserialised;
 
       it('should deserialise each item in the top-level data from the response', () => {
@@ -185,6 +189,48 @@ describe('deserialisers', () => {
         expect(address.houseNumber).toEqual(1007);
         expect(address.street).toEqual("Mountain Drive");
         expect(address.city).toEqual("Gotham City");
+      });
+    });
+
+    describe('JSON API top-level datum deserialisation of a subtype of an unregistered entity', () => {
+      const { deserialised, referents } = fromJsonApiTopLevel(FAKE_SINGLE_SUBTYPE_RESPONSE);
+      const CAT_1: Cat = deserialised;
+
+      it('should deserialise the top-level datum from the response, populating object attributes', () => {
+        expect(CAT_1).toEqual(jasmine.any(Cat));
+        const { id, type, name, livesLeft } = CAT_1;
+        expect(id).toEqual('mog');
+        expect(type).toEqual('cats');
+        expect(livesLeft).toEqual(8);
+        // supertype properties
+        expect(name).toEqual('Mog');
+      });
+
+      it('should deserialise decorated object links', () => {
+        expect(CAT_1).toEqual(jasmine.any(Cat));
+        const { self, alternative } = CAT_1;
+        expect(alternative).toEqual('http://alt.example.com/cats/mog');
+        // supertype properties
+        expect(self).toEqual('http://example.com/cats/mog');
+      });
+
+      it('should deserialise decorated object meta information', () => {
+        expect(CAT_1).toEqual(jasmine.any(Cat));
+        const { alterEgo, isGoodPet } = CAT_1;
+        expect(alterEgo).toEqual('FEROCIOUS TIGER');
+        // supertype properties
+        expect(isGoodPet).toEqual(true);
+      });
+
+      it('should deserialise related objects, populating their properties', () => {
+        expect(CAT_1.petOwner).toEqual(jasmine.any(Person));
+        const { fullName } = CAT_1.petOwner;
+        expect(fullName).toEqual('Meg da Witch');
+
+        // supertype properties
+        expect(CAT_1.chases).toEqual(jasmine.any(Animal));
+        const { name } = CAT_1.chases;
+        expect(name).toEqual('Miss Mouse');
       });
     });
   });

--- a/spec/serialisation/fake-single-subtype-response.json.ts
+++ b/spec/serialisation/fake-single-subtype-response.json.ts
@@ -1,0 +1,59 @@
+export const FAKE_SINGLE_SUBTYPE_RESPONSE = {
+  "data": {
+    "id": "mog",
+    "type": "cats",
+    "attributes": {
+      "name": "Mog",
+      "lives_left": 8,
+    },
+    "links": {
+      "self": "http://example.com/cats/mog",
+      "alt": "http://alt.example.com/cats/mog",
+    },
+    "meta": {
+      "is_good_pet": true,
+      "alter_ego": "FEROCIOUS TIGER",
+    },
+    "relationships": {
+      "chases": {
+        "data": {
+          "id": "miss_mouse",
+          "type": "mice"
+        }
+      },
+      "owner": {
+        "data": {
+          "id": "meg",
+          "type": "people"
+        }
+      }
+    },
+  },
+  "included": [
+    {
+      "id": "meg",
+      "type": "people",
+      "attributes": {
+        "firstName": "Meg",
+        "surname": "da Witch"
+      },
+      "links": {
+        "self": "http://example.com/people/meg",
+        "alt": "http://alt.example.com/people/meg",
+      }
+    },
+    {
+      "id": "miss_mouse",
+      "type": "mice",
+      "attributes": {
+        "name": "Miss Mouse"
+      },
+      "links": {
+        "self": "http://example.com/mice/miss_mouse"
+      },
+      "meta": {
+        "isGoodPet": false
+      },
+    }
+  ]
+}

--- a/spec/test-data/animal.ts
+++ b/spec/test-data/animal.ts
@@ -1,0 +1,14 @@
+import {
+  attribute,
+  JsonapiEntity,
+  link,
+  meta,
+  relationship,
+} from '../../src';
+
+export abstract class Animal extends JsonapiEntity {
+  @attribute() name: string;
+  @relationship() chases?: Animal;
+  @link() self: string;
+  @meta({ name: 'is_good_pet' }) isGoodPet: boolean;
+}

--- a/spec/test-data/cat.ts
+++ b/spec/test-data/cat.ts
@@ -1,0 +1,21 @@
+import {
+  attribute,
+  entity,
+  link,
+  meta,
+  JsonapiEntity,
+  relationship,
+} from '../../src';
+
+import { Animal } from './animal';
+import { Person } from './person';
+
+export type CatLivesLeft = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
+@entity({ type: 'cats' })
+export class Cat extends Animal {
+  @attribute({ name: 'lives_left' }) livesLeft: CatLivesLeft;
+  @link({ name: 'alt' }) alternative: string;
+  @meta({ name: 'alter_ego' }) alterEgo: string;
+  @relationship({ name: 'owner' }) petOwner: Person;
+}

--- a/spec/test-data/index.ts
+++ b/spec/test-data/index.ts
@@ -1,2 +1,5 @@
 export * from './address';
+export * from './animal';
+export * from './cat';
+export * from './mouse';
 export * from './person';

--- a/spec/test-data/mouse.ts
+++ b/spec/test-data/mouse.ts
@@ -1,0 +1,14 @@
+import {
+  attribute,
+  entity,
+  link,
+  meta,
+  JsonapiEntity,
+  relationship,
+} from '../../src';
+
+import { Animal } from './animal';
+
+@entity({ type: 'mice' })
+export class Mouse extends Animal {
+}

--- a/spec/test-data/person.ts
+++ b/spec/test-data/person.ts
@@ -22,18 +22,18 @@ export class Person extends JsonapiEntity {
 
   // relationships that are resolved to specific types
   @relationship()
-  address: Address;
+  address?: Address;
   @relationship({ name: 'old_addresses' })
-  oldAddresses: Address[];
+  oldAddresses?: Address[];
 
   // relationships that can be resolved to identifiers or specific types
   @relationship({ allowUnresolvedIdentifiers: true })
-  work_address: OneUnresolvedIdentifierOr<Address>;
+  work_address?: OneUnresolvedIdentifierOr<Address>;
   @relationship({ allowUnresolvedIdentifiers: true })
-  old_work_addresses: ManyUnresolvedIdentifiersOr<Address>;
+  old_work_addresses?: ManyUnresolvedIdentifiersOr<Address>;
 
   @link() self: string;
   @link({ name: 'alt' }) alternative: string;
 
-  @meta({ name: 'alter_ego' }) alterEgo: string;
+  @meta({ name: 'alter_ego' }) alterEgo?: string;
 }

--- a/src/decorators/attribute.ts
+++ b/src/decorators/attribute.ts
@@ -2,6 +2,8 @@ import {
   MetadataMap,
 } from './metadata-map';
 
+import { getEntityPrototypeChain } from './utils';
+
 const ATTRIBUTES_MAP = new MetadataMap<AttributeOptions>();
 
 export interface AttributeOptions {
@@ -20,5 +22,8 @@ export function attribute(options?: AttributeOptions): PropertyDecorator {
 export type AttributeMetadata = { [name: string]: AttributeOptions };
 
 export function getAttributeMetadata(target: any): AttributeMetadata {
-  return ATTRIBUTES_MAP.getMetadataByType(target.name);
+  return getEntityPrototypeChain(target).reduce(
+    (soFar, prototype) => Object.assign(soFar, ATTRIBUTES_MAP.getMetadataByType(prototype.name)),
+    {}
+  );
 }

--- a/src/decorators/link.ts
+++ b/src/decorators/link.ts
@@ -2,6 +2,8 @@ import {
   MetadataMap,
 } from './metadata-map';
 
+import { getEntityPrototypeChain } from './utils';
+
 const LINKS_MAP = new MetadataMap<LinkOptions>();
 
 export interface LinkOptions {
@@ -20,5 +22,8 @@ export function link(options?: LinkOptions): PropertyDecorator {
 export type LinkMetadata = { [name: string]: LinkOptions };
 
 export function getLinkMetadata(target: any): LinkMetadata {
-  return LINKS_MAP.getMetadataByType(target.name);
+  return getEntityPrototypeChain(target).reduce(
+    (soFar, prototype) => Object.assign(soFar, LINKS_MAP.getMetadataByType(prototype.name)),
+    {}
+  );
 }

--- a/src/decorators/meta.ts
+++ b/src/decorators/meta.ts
@@ -2,6 +2,8 @@ import {
   MetadataMap,
 } from './metadata-map';
 
+import { getEntityPrototypeChain } from './utils';
+
 const META_PROPERTIES_MAP = new MetadataMap<MetaOptions>();
 
 export interface MetaOptions {
@@ -20,5 +22,8 @@ export function meta(options?: MetaOptions): PropertyDecorator {
 export type MetaMetadata = { [name: string]: MetaOptions };
 
 export function getMetaMetadata(target: any): MetaMetadata {
-  return META_PROPERTIES_MAP.getMetadataByType(target.name);
+  return getEntityPrototypeChain(target).reduce(
+    (soFar, prototype) => Object.assign(soFar, META_PROPERTIES_MAP.getMetadataByType(prototype.name)),
+    {}
+  );
 }

--- a/src/decorators/relationship.ts
+++ b/src/decorators/relationship.ts
@@ -2,6 +2,8 @@ import {
   MetadataMap,
 } from './metadata-map';
 
+import { getEntityPrototypeChain } from './utils';
+
 const RELATIONSHIPS_MAP = new MetadataMap<RelationshipOptions>();
 
 export interface RelationshipOptions {
@@ -25,5 +27,8 @@ export function relationship(options?: RelationshipOptions): PropertyDecorator {
 export type RelationshipMetadata = { [name: string]: RelationshipOptions };
 
 export function getRelationshipMetadata(target: any): RelationshipMetadata {
-  return RELATIONSHIPS_MAP.getMetadataByType(target.name);
+  return getEntityPrototypeChain(target).reduce(
+    (soFar, prototype) => Object.assign(soFar, RELATIONSHIPS_MAP.getMetadataByType(prototype.name)),
+    {}
+  );
 }

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -1,0 +1,11 @@
+import { JsonapiEntity } from '../jsonapi';
+
+
+export function getEntityPrototypeChain(targetType: any): any[] {
+  const proto = Object.getPrototypeOf(targetType);
+
+  if (proto.prototype instanceof JsonapiEntity) {
+    return [...getEntityPrototypeChain(proto), targetType];
+  }
+  return [targetType];
+}


### PR DESCRIPTION
Add the ability to extend subclasses of `JsonapiEntity`, whilst drawing annotated properties from the prototype chain.

Prior to this PR, if you attempt to create a common superclass that extends `JsonapiEntity`, then extend with child `@entity` classes, the only properties to be deserialised are those declared in the subclass.

For example, the `@entity` class `Cat`:

https://github.com/junglebarry/jsonapi-transformers/blob/59f82faa73b2bd238f0c7eb3b36a3f64f1e14c87/spec/test-data/cat.ts#L1-L21

extends the (abstract) `Animal`:

https://github.com/junglebarry/jsonapi-transformers/blob/59f82faa73b2bd238f0c7eb3b36a3f64f1e14c87/spec/test-data/animal.ts#L1-L14

so you would expect a deserialised `Cat` to contain all the `Animal` fields and the `Cat` fields.

This PR add the ability to pull inherited JSON:API fields from the parent type, by making `attribute`, `link`, `meta`, and `relationship` traverse up the prototype chain.

However, this PR does not attempt to allow full OO extensions: it is not permitted to have an `@entity` subtype of a class that is, itself, and `@entity` (due to the odd prototype chain).

