### PR TITLE
Fix "TypeError: Class constructor <C> cannot be invoked without 'new'"

### DIFF
--- a/lib/decorators/entity.d.ts
+++ b/lib/decorators/entity.d.ts
@@ -1,6 +1,6 @@
 import { ResourceIdentifier } from '../jsonapi';
 export interface ResourceIdentifierConstructor {
-    new (): ResourceIdentifier;
+    new (...args: any[]): ResourceIdentifier;
 }
 export declare class TypeMap {
     private constructorsByJsonapiType;
@@ -21,4 +21,4 @@ export interface EntityOptions {
  * to be serialisable to and deserialisable from appropriate JSON:API data.
  *
  */
-export declare function entity(options: EntityOptions): (constructor: ResourceIdentifierConstructor) => any;
+export declare function entity(options: EntityOptions): (original: ResourceIdentifierConstructor) => any;

--- a/lib/decorators/entity.js
+++ b/lib/decorators/entity.js
@@ -33,16 +33,15 @@ exports.getConstructorForJsonapiType = getConstructorForJsonapiType;
  */
 function entity(options) {
     var type = options.type;
-    return function (constructor) {
-        var original = constructor;
+    return function (original) {
         // a utility function to generate instances of a class
         var construct = function (constructorFunc, args) {
-            var constructorClosure = function () {
-                return constructorFunc.apply(this, args);
+            var CustomJsonapiEntity = function () {
+                return new (constructorFunc.bind.apply(constructorFunc, [void 0].concat(args)))();
             };
-            constructorClosure.prototype = constructorFunc.prototype;
+            CustomJsonapiEntity.prototype = constructorFunc.prototype;
             // construct an instance and bind "type" correctly
-            var instance = new constructorClosure();
+            var instance = new CustomJsonapiEntity();
             instance.type = type;
             return instance;
         };

--- a/lib/decorators/metadata-map.js
+++ b/lib/decorators/metadata-map.js
@@ -8,10 +8,10 @@ var MetadataMap = /** @class */ (function () {
         return this.metadataByType[typeName] || {};
     };
     MetadataMap.prototype.setMetadataByType = function (typeName, keyName, metadata) {
+        var _a;
         this.metadataByType[typeName] = Object.assign({}, this.getMetadataByType(typeName), (_a = {},
             _a[keyName] = metadata,
             _a));
-        var _a;
     };
     return MetadataMap;
 }());

--- a/lib/serialisation/deserialisers.js
+++ b/lib/serialisation/deserialisers.js
@@ -57,9 +57,10 @@ exports.fromJsonApiTopLevel = fromJsonApiTopLevel;
  * @return {any} - a resource object, deserialised from JSON:API
  */
 function fromJsonApiResourceObject(jsonapiResource, resourceObjectsByTypeAndId, deserialisedObjects) {
+    var _a;
     if (deserialisedObjects === void 0) { deserialisedObjects = {}; }
     // deconstruct primary data and remap into an instance of the chosen type
-    var id = jsonapiResource.id, type = jsonapiResource.type, _a = jsonapiResource.attributes, attributes = _a === void 0 ? {} : _a, _b = jsonapiResource.links, links = _b === void 0 ? {} : _b, _c = jsonapiResource.meta, meta = _c === void 0 ? {} : _c, _d = jsonapiResource.relationships, relationships = _d === void 0 ? {} : _d;
+    var id = jsonapiResource.id, type = jsonapiResource.type, _b = jsonapiResource.attributes, attributes = _b === void 0 ? {} : _b, _c = jsonapiResource.links, links = _c === void 0 ? {} : _c, _d = jsonapiResource.meta, meta = _d === void 0 ? {} : _d, _e = jsonapiResource.relationships, relationships = _e === void 0 ? {} : _e;
     // fetch the Typescript class responsible for deserialisation
     var targetType = decorators_1.getClassForJsonapiType(type);
     if (!targetType) {
@@ -80,9 +81,9 @@ function fromJsonApiResourceObject(jsonapiResource, resourceObjectsByTypeAndId, 
     instance.type = type;
     // add to the list of deserialised objects, so recursive lookup works
     var typeAndId = byTypeAndId(instance);
-    Object.assign(deserialisedObjects, (_e = {},
-        _e[typeAndId] = instance,
-        _e));
+    Object.assign(deserialisedObjects, (_a = {},
+        _a[typeAndId] = instance,
+        _a));
     // transfer attributes from JSON API to target
     Object.keys(attributeMetadata).forEach(function (attribute) {
         var metadata = attributeMetadata[attribute];
@@ -125,7 +126,6 @@ function fromJsonApiResourceObject(jsonapiResource, resourceObjectsByTypeAndId, 
         }
     });
     return instance;
-    var _e;
 }
 exports.fromJsonApiResourceObject = fromJsonApiResourceObject;
 /**

--- a/lib/serialisation/serialisers.js
+++ b/lib/serialisation/serialisers.js
@@ -13,23 +13,23 @@ function toJsonApi(target) {
     // convert attributes
     var attributeMetadata = decorators_1.getAttributeMetadata(target.constructor);
     var attributeReducer = function (soFar, attr) {
+        var _a;
         var metadata = attributeMetadata[attr];
         var targetAttribute = target[attr];
         return !utils_1.isDefined(targetAttribute) ? soFar : Object.assign(soFar, (_a = {},
             _a[metadata.name] = targetAttribute,
             _a));
-        var _a;
     };
     var attributes = Object.keys(attributeMetadata).reduce(attributeReducer, {});
     // convert relationships
     var relationshipMetadata = decorators_1.getRelationshipMetadata(target.constructor);
     var relationshipReducer = function (soFar, relationshipName) {
+        var _a;
         var metadata = relationshipMetadata[relationshipName];
         var linkage = jsonapi_1.jsonapiLinkage(target[relationshipName]);
         return !utils_1.isDefined(linkage) ? soFar : Object.assign(soFar, (_a = {},
             _a[metadata.name] = { data: linkage },
             _a));
-        var _a;
     };
     var relationships = Object.keys(relationshipMetadata).reduce(relationshipReducer, {});
     // compose the object and return

--- a/lib/serialisation/utils.d.ts
+++ b/lib/serialisation/utils.d.ts
@@ -16,7 +16,7 @@ export declare function isEmptyObject(obj: any): boolean;
  * @return {boolean} - `true` if the value is defined (including null); `false` otherwise.
  */
 export declare function isDefined(value: any): boolean;
-export declare type KeyingFunction<T> = (T) => string;
+export declare type KeyingFunction<T> = (t: T) => string;
 /**
  * Convert an array into a keyed object for constant-time lookup.
  *

--- a/lib/serialisation/utils.js
+++ b/lib/serialisation/utils.js
@@ -33,10 +33,10 @@ exports.isDefined = isDefined;
  */
 function keyBy(array, keyFunc) {
     var reducer = function (soFar, element) {
+        var _a;
         return Object.assign(soFar, (_a = {},
             _a[keyFunc(element)] = element,
             _a));
-        var _a;
     };
     return array.reduce(reducer, {});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1928,9 +1928,9 @@
       }
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "unc-path-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "gulp": "3.9.1",
     "gulp-jasmine": "2.4.2",
     "gulp-typescript": "3.1.6",
-    "typescript": "2.6.2"
+    "typescript": "3.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Typescript-based JSON API serialisation/deserialisation",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/decorators/entity.ts
+++ b/src/decorators/entity.ts
@@ -3,7 +3,7 @@ import {
 } from '../jsonapi';
 
 export interface ResourceIdentifierConstructor {
-  new (): ResourceIdentifier
+  new (...args: any[]): ResourceIdentifier
 }
 
 export class TypeMap {
@@ -44,18 +44,16 @@ export interface EntityOptions {
 export function entity(options: EntityOptions) {
   const { type } = options;
 
-  return (constructor: ResourceIdentifierConstructor) => {
-    const original = constructor;
-
+  return (original: ResourceIdentifierConstructor) => {
     // a utility function to generate instances of a class
     const construct = (constructorFunc: ResourceIdentifierConstructor, args) => {
-      const constructorClosure : any = function () {
-        return constructorFunc.apply(this, args);
+      const CustomJsonapiEntity : any = function () {
+        return new constructorFunc(...args);
       }
-      constructorClosure.prototype = constructorFunc.prototype;
+      CustomJsonapiEntity.prototype = constructorFunc.prototype;
 
       // construct an instance and bind "type" correctly
-      const instance = new constructorClosure();
+      const instance = new CustomJsonapiEntity();
       instance.type = type;
       return instance;
     };

--- a/src/serialisation/utils.ts
+++ b/src/serialisation/utils.ts
@@ -22,7 +22,7 @@ export function isDefined(value: any): boolean {
   return typeof value !== 'undefined';
 }
 
-export type KeyingFunction<T> = (T) => string;
+export type KeyingFunction<T> = (t: T) => string;
 
 /**
  * Convert an array into a keyed object for constant-time lookup.


### PR DESCRIPTION
The above error was being reported on upgrading to ES2105 as a compilation target.  This change ensures that `new` is being used rather than `apply`.

We also upgrade Typescript fo tighter type-checking.