### PR TITLE
Store decorator metadata by constructor type rather than `constructor.name`

### DIFF
--- a/lib/decorators/attribute.js
+++ b/lib/decorators/attribute.js
@@ -7,13 +7,13 @@ var ATTRIBUTES_MAP = new metadata_map_1.MetadataMap();
 function attribute(options) {
     var opts = options || {};
     return function (target, key) {
-        ATTRIBUTES_MAP.setMetadataByType(target.constructor.name, key, Object.assign({
+        ATTRIBUTES_MAP.setMetadataByType(target.constructor, key, Object.assign({
             name: key,
         }, opts));
     };
 }
 exports.attribute = attribute;
 function getAttributeMetadata(target) {
-    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, ATTRIBUTES_MAP.getMetadataByType(prototype.name)); }, {});
+    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, ATTRIBUTES_MAP.getMetadataByType(prototype)); }, {});
 }
 exports.getAttributeMetadata = getAttributeMetadata;

--- a/lib/decorators/link.js
+++ b/lib/decorators/link.js
@@ -7,13 +7,13 @@ var LINKS_MAP = new metadata_map_1.MetadataMap();
 function link(options) {
     var opts = options || {};
     return function (target, key) {
-        LINKS_MAP.setMetadataByType(target.constructor.name, key, Object.assign({
+        LINKS_MAP.setMetadataByType(target.constructor, key, Object.assign({
             name: key,
         }, opts));
     };
 }
 exports.link = link;
 function getLinkMetadata(target) {
-    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, LINKS_MAP.getMetadataByType(prototype.name)); }, {});
+    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, LINKS_MAP.getMetadataByType(prototype)); }, {});
 }
 exports.getLinkMetadata = getLinkMetadata;

--- a/lib/decorators/meta.js
+++ b/lib/decorators/meta.js
@@ -7,13 +7,13 @@ var META_PROPERTIES_MAP = new metadata_map_1.MetadataMap();
 function meta(options) {
     var opts = options || {};
     return function (target, key) {
-        META_PROPERTIES_MAP.setMetadataByType(target.constructor.name, key, Object.assign({
+        META_PROPERTIES_MAP.setMetadataByType(target.constructor, key, Object.assign({
             name: key,
         }, opts));
     };
 }
 exports.meta = meta;
 function getMetaMetadata(target) {
-    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, META_PROPERTIES_MAP.getMetadataByType(prototype.name)); }, {});
+    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, META_PROPERTIES_MAP.getMetadataByType(prototype)); }, {});
 }
 exports.getMetaMetadata = getMetaMetadata;

--- a/lib/decorators/metadata-map.d.ts
+++ b/lib/decorators/metadata-map.d.ts
@@ -1,11 +1,9 @@
 export declare type MetadataByPropertyName<T> = {
     [attributeName: string]: T;
 };
-export declare type PropertyTypesForType<T> = {
-    [typeName: string]: MetadataByPropertyName<T>;
-};
+export declare type PropertyTypesForType<T> = Map<any, MetadataByPropertyName<T>>;
 export declare class MetadataMap<T> {
     private metadataByType;
-    getMetadataByType(typeName: string): MetadataByPropertyName<T>;
-    setMetadataByType(typeName: string, keyName: string, metadata: T): void;
+    getMetadataByType(classType: any): MetadataByPropertyName<T>;
+    setMetadataByType(classType: any, keyName: string, metadata: T): void;
 }

--- a/lib/decorators/metadata-map.js
+++ b/lib/decorators/metadata-map.js
@@ -3,16 +3,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.MetadataMap = void 0;
 var MetadataMap = /** @class */ (function () {
     function MetadataMap() {
-        this.metadataByType = {};
+        this.metadataByType = new Map();
     }
-    MetadataMap.prototype.getMetadataByType = function (typeName) {
-        return this.metadataByType[typeName] || {};
+    MetadataMap.prototype.getMetadataByType = function (classType) {
+        return this.metadataByType.get(classType) || {};
     };
-    MetadataMap.prototype.setMetadataByType = function (typeName, keyName, metadata) {
+    MetadataMap.prototype.setMetadataByType = function (classType, keyName, metadata) {
         var _a;
-        this.metadataByType[typeName] = Object.assign({}, this.getMetadataByType(typeName), (_a = {},
-            _a[keyName] = metadata,
-            _a));
+        this.metadataByType.set(classType, Object.assign({}, this.getMetadataByType(classType), (_a = {}, _a[keyName] = metadata, _a)));
     };
     return MetadataMap;
 }());

--- a/lib/decorators/relationship.js
+++ b/lib/decorators/relationship.js
@@ -10,13 +10,13 @@ var DefaultRelationshipOptions = {
 function relationship(options) {
     var opts = Object.assign({}, DefaultRelationshipOptions, options || {});
     return function (target, key) {
-        RELATIONSHIPS_MAP.setMetadataByType(target.constructor.name, key, Object.assign({
+        RELATIONSHIPS_MAP.setMetadataByType(target.constructor, key, Object.assign({
             name: key,
         }, opts));
     };
 }
 exports.relationship = relationship;
 function getRelationshipMetadata(target) {
-    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, RELATIONSHIPS_MAP.getMetadataByType(prototype.name)); }, {});
+    return utils_1.getEntityPrototypeChain(target).reduce(function (soFar, prototype) { return Object.assign(soFar, RELATIONSHIPS_MAP.getMetadataByType(prototype)); }, {});
 }
 exports.getRelationshipMetadata = getRelationshipMetadata;

--- a/src/decorators/attribute.ts
+++ b/src/decorators/attribute.ts
@@ -13,7 +13,7 @@ export interface AttributeOptions {
 export function attribute(options?: AttributeOptions): PropertyDecorator {
   const opts = options || {};
   return (target: any, key: string) => {
-    ATTRIBUTES_MAP.setMetadataByType(target.constructor.name, key, Object.assign({
+    ATTRIBUTES_MAP.setMetadataByType(target.constructor, key, Object.assign({
       name: key,
     }, opts));
   }
@@ -23,7 +23,7 @@ export type AttributeMetadata = { [name: string]: AttributeOptions };
 
 export function getAttributeMetadata(target: any): AttributeMetadata {
   return getEntityPrototypeChain(target).reduce(
-    (soFar, prototype) => Object.assign(soFar, ATTRIBUTES_MAP.getMetadataByType(prototype.name)),
+    (soFar, prototype) => Object.assign(soFar, ATTRIBUTES_MAP.getMetadataByType(prototype)),
     {}
   );
 }

--- a/src/decorators/link.ts
+++ b/src/decorators/link.ts
@@ -13,7 +13,7 @@ export interface LinkOptions {
 export function link(options?: LinkOptions): PropertyDecorator {
   const opts = options || {};
   return (target: any, key: string) => {
-    LINKS_MAP.setMetadataByType(target.constructor.name, key, Object.assign({
+    LINKS_MAP.setMetadataByType(target.constructor, key, Object.assign({
       name: key,
     }, opts));
   }
@@ -23,7 +23,7 @@ export type LinkMetadata = { [name: string]: LinkOptions };
 
 export function getLinkMetadata(target: any): LinkMetadata {
   return getEntityPrototypeChain(target).reduce(
-    (soFar, prototype) => Object.assign(soFar, LINKS_MAP.getMetadataByType(prototype.name)),
+    (soFar, prototype) => Object.assign(soFar, LINKS_MAP.getMetadataByType(prototype)),
     {}
   );
 }

--- a/src/decorators/meta.ts
+++ b/src/decorators/meta.ts
@@ -13,7 +13,7 @@ export interface MetaOptions {
 export function meta(options?: MetaOptions): PropertyDecorator {
   const opts = options || {};
   return (target: any, key: string) => {
-    META_PROPERTIES_MAP.setMetadataByType(target.constructor.name, key, Object.assign({
+    META_PROPERTIES_MAP.setMetadataByType(target.constructor, key, Object.assign({
       name: key,
     }, opts));
   }
@@ -23,7 +23,7 @@ export type MetaMetadata = { [name: string]: MetaOptions };
 
 export function getMetaMetadata(target: any): MetaMetadata {
   return getEntityPrototypeChain(target).reduce(
-    (soFar, prototype) => Object.assign(soFar, META_PROPERTIES_MAP.getMetadataByType(prototype.name)),
+    (soFar, prototype) => Object.assign(soFar, META_PROPERTIES_MAP.getMetadataByType(prototype)),
     {}
   );
 }

--- a/src/decorators/metadata-map.ts
+++ b/src/decorators/metadata-map.ts
@@ -1,16 +1,17 @@
 export type MetadataByPropertyName<T> = { [attributeName: string]: T };
-export type PropertyTypesForType<T> = { [typeName: string]: MetadataByPropertyName<T> };
+export type PropertyTypesForType<T> = Map<any, MetadataByPropertyName<T>>;
 
 export class MetadataMap<T> {
-  private metadataByType: PropertyTypesForType<T> = {};
+  private metadataByType = new Map<any, MetadataByPropertyName<T>>();
 
-  getMetadataByType(typeName: string): MetadataByPropertyName<T> {
-    return this.metadataByType[typeName] || {};
+  getMetadataByType(classType: any): MetadataByPropertyName<T> {
+    return this.metadataByType.get(classType) || {};
   }
 
-  setMetadataByType(typeName: string, keyName: string, metadata: T): void {
-    this.metadataByType[typeName] = Object.assign({}, this.getMetadataByType(typeName), {
-      [keyName]: metadata,
-    });
+  setMetadataByType(classType: any, keyName: string, metadata: T): void {
+    this.metadataByType.set(
+      classType,
+      Object.assign({}, this.getMetadataByType(classType), { [keyName]: metadata })
+    );
   }
 }

--- a/src/decorators/relationship.ts
+++ b/src/decorators/relationship.ts
@@ -1,7 +1,4 @@
-import {
-  MetadataMap,
-} from './metadata-map';
-
+import { MetadataMap } from './metadata-map';
 import { getEntityPrototypeChain } from './utils';
 
 const RELATIONSHIPS_MAP = new MetadataMap<RelationshipOptions>();
@@ -18,7 +15,7 @@ const DefaultRelationshipOptions: RelationshipOptions = {
 export function relationship(options?: RelationshipOptions): PropertyDecorator {
   const opts = Object.assign({}, DefaultRelationshipOptions, options || {});
   return (target : any, key: string) => {
-    RELATIONSHIPS_MAP.setMetadataByType(target.constructor.name, key, Object.assign({
+    RELATIONSHIPS_MAP.setMetadataByType(target.constructor, key, Object.assign({
       name: key,
     }, opts));
   }
@@ -28,7 +25,7 @@ export type RelationshipMetadata = { [name: string]: RelationshipOptions };
 
 export function getRelationshipMetadata(target: any): RelationshipMetadata {
   return getEntityPrototypeChain(target).reduce(
-    (soFar, prototype) => Object.assign(soFar, RELATIONSHIPS_MAP.getMetadataByType(prototype.name)),
+    (soFar, prototype) => Object.assign(soFar, RELATIONSHIPS_MAP.getMetadataByType(prototype)),
     {}
   );
 }


### PR DESCRIPTION
We have had some issues created by Angular's build system whereby the decorator metadata was not being correctly segmented by entity. The root cause seems to be some of the mangling steps employed during the Angular build, which means that [`constructor.name` does not retain the original class name](https://github.com/angular/angular-cli/issues/5168), and instead resolves to something like `'n'`.

This can be hard to diagnose because it tended to only manifest where entities have a property with the same but with conflicting configuration (e.g. two entities with a relationship called `resource`, one with `allowUnresolvedIdentifiers: true`, the other with `allowUnresolvedIdentifiers: false`.

To fix this, we move metadata storage from string-keyed objects to object-keyed `Map`s. By doing this, the mangler does not interfere with the storage keys, and we keep these matters separate.