### PR TITLE
feat: use constructors not names for metadata storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.8.0",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-transformers",
-  "version": "0.8.0",
+  "version": "0.0.0",
   "description": "Typescript-based JSON API serialisation/deserialisation",
   "files": [
     "lib/**/*.d.ts",


### PR DESCRIPTION
The contents of the PR is simply to remove the the version number from package.json, but this drives a new feature release covering mangler-safe metadata storage. Fixes bugs in use under build processes that mangle the `constructor.name`, upon which the decorators rely.