### PR TITLE
feat: partially-specify properties via constructor

### DIFF
--- a/spec/decorators/entity.spec.ts
+++ b/spec/decorators/entity.spec.ts
@@ -1,32 +1,27 @@
 import { describe, expect, it } from "@jest/globals";
 import { Address, Person } from "../test-data";
 
-const address1: Address = new Address();
-address1.id = "address1";
-address1.houseNumber = 8;
-address1.street = "Acacia Road";
-address1.city = "Nuttytown";
-address1.county = "West Nutshire";
+const address1: Address = new Address({
+  id: "address1",
+  houseNumber: 8,
+  street: "Acacia Road",
+  city: "Nuttytown",
+  county: "West Nutshire",
+});
 
-const address1WithExplicitType: Address = new Address();
-address1WithExplicitType.id = "address1";
-address1WithExplicitType.type = "addresses";
-address1WithExplicitType.houseNumber = 8;
-address1WithExplicitType.street = "Acacia Road";
-address1WithExplicitType.city = "Nuttytown";
-address1WithExplicitType.county = "West Nutshire";
+const address2: Address = new Address({
+  id: "address2",
+  street: "Mountain Drive",
+  city: "Gotham City",
+});
 
-const address2: Address = new Address();
-address2.id = "address2";
-address2.street = "Mountain Drive";
-address2.city = "Gotham City";
-
-const person1: Person = new Person();
-person1.id = "person1";
-person1.firstName = "Eric";
-person1.surname = "Wimp";
-person1.address = address1;
-person1.oldAddresses = [address2];
+const person1: Person = new Person({
+  id: "person1",
+  firstName: "Eric",
+  surname: "Wimp",
+  address: address1,
+  oldAddresses: [address2],
+});
 
 describe("entity", () => {
   it("should respect instanceof", () => {
@@ -39,10 +34,6 @@ describe("entity", () => {
     expect(address1.type).toEqual("addresses");
     expect(address2.type).toEqual("addresses");
     expect(person1.type).toEqual("people");
-  });
-
-  it("should respect equality, even when type is manually specified", () => {
-    expect(address1).toEqual(address1WithExplicitType);
   });
 
   it("should permit a natural JSON interpretation", () => {

--- a/spec/jsonapi/jsonapi-entity.spec.ts
+++ b/spec/jsonapi/jsonapi-entity.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "@jest/globals";
+import { attribute, JsonapiEntity, meta, relationship } from "../../src";
+
+describe("JsonapiEntity", () => {
+  class FakeSimpleJsonapiEntity extends JsonapiEntity<FakeSimpleJsonapiEntity> {
+    readonly type = "simples";
+  }
+
+  class FakeComplexJsonapiEntity extends JsonapiEntity<FakeComplexJsonapiEntity> {
+    readonly type = "complexities";
+
+    someNonJsonapiProperty: string;
+
+    @attribute() someAttr: string;
+    @attribute({ name: "some_other_attr" }) someOtherAttr: string;
+    @meta() someMeta: string;
+    @meta({ name: "some_other_meta" }) someOtherMeta: string;
+    @relationship() someSimple: FakeSimpleJsonapiEntity;
+    @relationship({ name: "some_other_simple" })
+    someOtherSimple: FakeSimpleJsonapiEntity;
+  }
+
+  describe("construction should permit property specification for all properties", () => {
+    it("should return true for a valid UnresolvedResourceIdentifier", () => {
+      const fake = new FakeComplexJsonapiEntity({
+        id: "complex1",
+        someNonJsonapiProperty: "someNonJsonapiProperty!",
+        someAttr: "someAttr!",
+        someOtherAttr: "someOtherAttr!",
+        someMeta: "someMeta!",
+        someOtherMeta: "someOtherMeta!",
+        someSimple: new FakeSimpleJsonapiEntity({ id: "simple1" }),
+        someOtherSimple: new FakeSimpleJsonapiEntity({ id: "simple2" }),
+      });
+      expect(fake.id).toEqual("complex1");
+      expect(fake.someNonJsonapiProperty).toEqual("someNonJsonapiProperty!");
+      expect(fake.someAttr).toEqual("someAttr!");
+      expect(fake.someOtherAttr).toEqual("someOtherAttr!");
+      expect(fake.someMeta).toEqual("someMeta!");
+      expect(fake.someOtherMeta).toEqual("someOtherMeta!");
+      expect(fake.someSimple).toEqual(
+        new FakeSimpleJsonapiEntity({ id: "simple1" })
+      );
+      expect(fake.someOtherSimple).toEqual(
+        new FakeSimpleJsonapiEntity({ id: "simple2" })
+      );
+    });
+  });
+});

--- a/spec/jsonapi/unresolved-identifiers.spec.ts
+++ b/spec/jsonapi/unresolved-identifiers.spec.ts
@@ -6,7 +6,7 @@ import {
 } from "../../src";
 
 describe("unresolved-identifiers", () => {
-  class FakeJsonapiEntity extends JsonapiEntity {
+  class FakeJsonapiEntity extends JsonapiEntity<FakeJsonapiEntity> {
     id = "foo";
     type = "things";
   }

--- a/spec/serialisation/serialisers.spec.ts
+++ b/spec/serialisation/serialisers.spec.ts
@@ -8,37 +8,51 @@ import {
 
 import { Address, Person } from "../test-data";
 
-const address1: Address = new Address();
-address1.id = "address1";
-address1.houseNumber = 8;
-address1.street = "Acacia Road";
-address1.city = "Nuttytown";
-address1.county = "West Nutshire";
+const address1: Address = new Address({
+  id: "address1",
+  houseNumber: 8,
+  street: "Acacia Road",
+  city: "Nuttytown",
+  county: "West Nutshire",
+});
 
 const address2: Address = new Address();
 address2.id = "address2";
 address2.street = "Mountain Drive";
 address2.city = "Gotham City";
 
-const person1: Person = new Person();
-person1.id = "person1";
-person1.firstName = "Eric";
-person1.surname = "Wimp";
-person1.address = address1;
-person1.oldAddresses = [address2];
-person1.createdDateTime = "2021-12-06T18:15:45";
+const person1: Person = new Person({
+  id: "person1",
+  firstName: "Eric",
+  surname: "Wimp",
+  address: address1,
+  oldAddresses: [address2],
+  createdDateTime: "2021-12-06T18:15:45",
+});
 
-const person2: Person = new Person();
-person2.id = "person2";
-person2.firstName = "Bruce";
-person2.surname = "Wayne";
-person2.work_address = address2;
-person2.old_work_addresses = [address1];
-person2.alterEgo = "2021-12-06T18:31:11";
+const person2: Person = new Person({
+  id: "person2",
+  firstName: "Bruce",
+  surname: "Wayne",
+  work_address: address2,
+  old_work_addresses: [address1],
+  alterEgo: "2021-12-06T18:31:11",
+});
 
 describe("serialisers", () => {
   describe("toJsonApi", () => {
-    it("should serialise to JSON API including attributes", () => {
+    it("should serialise to JSON API including attributes - legacy property assignment", () => {
+      expect(toJsonApi(address2)).toEqual({
+        id: "address2",
+        type: "addresses",
+        attributes: {
+          street: "Mountain Drive",
+          city: "Gotham City",
+        },
+      });
+    });
+
+    it("should serialise to JSON API including attributes - constructor assignment", () => {
       expect(toJsonApi(address1)).toEqual({
         id: "address1",
         type: "addresses",
@@ -47,15 +61,6 @@ describe("serialisers", () => {
           street: "Acacia Road",
           city: "Nuttytown",
           county: "West Nutshire",
-        },
-      });
-
-      expect(toJsonApi(address2)).toEqual({
-        id: "address2",
-        type: "addresses",
-        attributes: {
-          street: "Mountain Drive",
-          city: "Gotham City",
         },
       });
     });

--- a/spec/test-data/address.ts
+++ b/spec/test-data/address.ts
@@ -3,7 +3,7 @@ import { attribute, entity, relationship, JsonapiEntity } from "../../src";
 import { Person } from "./person";
 
 @entity({ type: "addresses" })
-export class Address extends JsonapiEntity {
+export class Address extends JsonapiEntity<Address> {
   @attribute() houseNumber?: number;
   @attribute() street: string;
   @attribute() city: string;

--- a/spec/test-data/animal.ts
+++ b/spec/test-data/animal.ts
@@ -1,8 +1,8 @@
 import { attribute, JsonapiEntity, link, meta, relationship } from "../../src";
 
-export abstract class Animal extends JsonapiEntity {
+export abstract class Animal<A extends Animal<A>> extends JsonapiEntity<A> {
   @attribute() name: string;
-  @relationship() chases: Animal | null;
+  @relationship() chases: Animal<any> | null;
   @link() self: string;
   @meta({ name: "created_date_time" }) createdDateTime: string;
 }

--- a/spec/test-data/author.ts
+++ b/spec/test-data/author.ts
@@ -1,7 +1,7 @@
 import { attribute, entity, meta, JsonapiEntity } from "../../src";
 
 @entity({ type: "authors" })
-export class Author extends JsonapiEntity {
+export class Author extends JsonapiEntity<Author> {
   @meta() lastLoginDateTime: string;
   @attribute() name: string;
 }

--- a/spec/test-data/blog-post.ts
+++ b/spec/test-data/blog-post.ts
@@ -10,7 +10,7 @@ import { Author } from "./author";
 import { Tag } from "./tag";
 
 @entity({ type: "blog_posts" })
-export class BlogPost extends JsonapiEntity {
+export class BlogPost extends JsonapiEntity<BlogPost> {
   @meta() createdDateTime: string;
   @attribute() title: string;
   @attribute() content: string;

--- a/spec/test-data/cat.ts
+++ b/spec/test-data/cat.ts
@@ -6,7 +6,7 @@ import { Person } from "./person";
 export type CatLivesLeft = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
 @entity({ type: "cats" })
-export class Cat extends Animal {
+export class Cat extends Animal<Cat> {
   @attribute({ name: "lives_left" }) livesLeft: CatLivesLeft;
   @link({ name: "alt" }) alternative: string;
   @relationship({ name: "owner" }) petOwner: Person;

--- a/spec/test-data/mouse.ts
+++ b/spec/test-data/mouse.ts
@@ -3,4 +3,4 @@ import { entity } from "../../src";
 import { Animal } from "./animal";
 
 @entity({ type: "mice" })
-export class Mouse extends Animal {}
+export class Mouse extends Animal<Mouse> {}

--- a/spec/test-data/person.ts
+++ b/spec/test-data/person.ts
@@ -12,7 +12,7 @@ import {
 import { Address } from "./address";
 
 @entity({ type: "people" })
-export class Person extends JsonapiEntity {
+export class Person extends JsonapiEntity<Person> {
   @meta({ name: "created_date_time" }) createdDateTime: string;
 
   @attribute() firstName: string;
@@ -37,4 +37,8 @@ export class Person extends JsonapiEntity {
 
   @link() self: string;
   @link({ name: "alt" }) alternative: string;
+
+  constructor(propertyValues: Partial<Person>) {
+    super(propertyValues);
+  }
 }

--- a/spec/test-data/tag.ts
+++ b/spec/test-data/tag.ts
@@ -1,6 +1,6 @@
 import { attribute, entity, JsonapiEntity } from "../../src";
 
 @entity({ type: "tags" })
-export class Tag extends JsonapiEntity {
+export class Tag extends JsonapiEntity<Tag> {
   @attribute() label: string;
 }

--- a/src/jsonapi/index.ts
+++ b/src/jsonapi/index.ts
@@ -1,2 +1,3 @@
+export * from "./jsonapi-entity";
 export * from "./types";
 export * from "./unresolved-identifiers";

--- a/src/jsonapi/jsonapi-entity.ts
+++ b/src/jsonapi/jsonapi-entity.ts
@@ -1,0 +1,17 @@
+import { ResourceIdentifier } from "./types";
+
+/**
+ * JSON:API base class providing `id` and `type` for resources.
+ */
+export class JsonapiEntity<E extends JsonapiEntity<E>>
+  implements ResourceIdentifier
+{
+  id: string;
+  readonly type: string;
+
+  constructor(properties: Partial<E> = {}) {
+    Object.keys(properties).forEach((property) => {
+      this[property] = properties[property];
+    });
+  }
+}

--- a/src/jsonapi/types.ts
+++ b/src/jsonapi/types.ts
@@ -3,7 +3,7 @@
  */
 export interface JsonapiIdentifier {
   id: string;
-  type: string;
+  readonly type: string;
 }
 
 /**
@@ -61,14 +61,6 @@ export interface ResourceObject extends ResourceIdentifier {
   links?: LinksObject;
   meta?: MetaObject;
   relationships?: { [relationshipName: string]: RelationshipsObject };
-}
-
-/**
- * JSON:API base class providing `id` and `type` for resources.
- */
-export class JsonapiEntity implements ResourceIdentifier {
-  id: string;
-  type: string;
 }
 
 /**

--- a/src/serialisation/deserialisers.ts
+++ b/src/serialisation/deserialisers.ts
@@ -135,6 +135,7 @@ export function fromJsonApiResourceObject(
   if (!targetConstructor) {
     throw new Error(`No target entity constructor for type: ${type}`);
   }
+  targetConstructor.prototype.type = type;
 
   // fetch type-specific data
   const attributeMetadata = getAttributeMetadata(targetConstructor);
@@ -143,9 +144,7 @@ export function fromJsonApiResourceObject(
   const relationshipMetadata = getRelationshipMetadata(targetConstructor);
 
   // construct a basic instance with only ID and type (by means of entity) specified
-  const instance = new targetType();
-  instance.id = id;
-  instance.type = type;
+  const instance = new targetType({ id });
 
   // add to the list of deserialised objects, so recursive lookup works
   const typeAndId = byTypeAndId(instance);


### PR DESCRIPTION
This PR includes a **breaking change** to allow properties to be partially-specified via the constructor parameter.

In practical terms this meant that:

```typescript
const david = new Author();
david.id = "david";
david.name = "David Brooks";
david.lastLoginDateTime = "2021-07-24T11:00:00.000Z";
```

could be rewritten as:

```typescript
const david = new Author({
  id: "david",
  name: "David Brooks",
  lastLoginDateTime: "2021-07-24T11:00:00.000Z",
});
```

Though the original format will still work.

However, to facilitate this, the default constructor for `JsonapiEntity` needed access to the type being instantiated:

```typescript
constructor(properties: Partial<E> = {})
```

where `E` must be the type in question.

In order to provide this, the `JsonapiEntity` subtype needed to be available to the constructor, and to achieve this, new `JsonapiEntity` subtypes must include the type as they extend that base type. In practice, this means that:

```typescript
@entity({ type: "authors" })
export class Author extends JsonapiEntity {
  @meta() lastLoginDateTime: string;
  @attribute() name: string;
}
```

must be rewritten as:

```typescript
@entity({ type: "authors" })
export class Author extends JsonapiEntity<Author> {
  // note the type parameter on the supertype
  @meta() lastLoginDateTime: string;
  @attribute() name: string;
}
```

As part of this change, we also moved `JsonapiEntity` into its own file, so imports of the form:

```typescript
import { JsonapiEntity } from "jsonapi-transformers/src/jsonapi/types";
```

will not work, and need to be migrated to:

```typescript
import { JsonapiEntity } from "jsonapi-transformers/src/jsonapi/jsonapi-entity";
```

However, we recommend importing from `'jsonapi-transformers'` rather than delving into the internal structure.
